### PR TITLE
Add Lua implementation

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -292,5 +292,29 @@
       "working": null
     },
     "audits": []
+  },
+  {
+    "name": "peter-evans/paseto-lua",
+    "url": "https://github.com/peter-evans/paseto-lua",
+    "authors": [
+      {
+        "name": "Peter Evans",
+        "homepage": "https://github.com/peter-evans"
+      }
+    ],
+    "comment": null,
+    "language": "Lua",
+    "features": {
+      "v1.local": false,
+      "v1.public": false,
+      "v2.local": true,
+      "v2.public": true
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": null
+    },
+    "audits": []
   }
 ]


### PR DESCRIPTION
Adding a Lua implementation of PASETO.

The official test vectors can be checked here:
https://github.com/peter-evans/paseto-lua/blob/master/spec/v2_vector_spec.lua
The test execution can be checked here:
https://travis-ci.org/peter-evans/paseto-lua
