### PR TITLE
Add atholbro/paseto Java Implementation

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -194,6 +194,30 @@
     "audits": []
   },
   {
+    "name": "atholbro/paseto",
+    "url": "https://github.com/atholbro/paseto",
+    "authors": [
+      {
+        "name": "Andrew Holbrook",
+        "homepage": "https://github.com/atholbro"
+      }
+    ],
+    "comment": null,
+    "language": "Java",
+    "features": {
+      "v1.local": true,
+      "v1.public": true,
+      "v2.local": true,
+      "v2.public": true
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
+    },
+    "audits": []
+  },
+  {
     "name": "o1egl/paseto",
     "url": "https://github.com/o1egl/paseto",
     "authors": [


### PR DESCRIPTION
Hey,

I wrote another Java implementation which supports all Paseto versions + JsonToken. There's also validation support for token expiry times, issued times, and the various JSON token claims provided through the high level API. My library is quite different from the existing Java library so I figure it's worthwhile to release it.

Test runs are here:
https://codecov.io/gh/atholbro/paseto

And the test vectors:
https://github.com/atholbro/paseto/blob/master/test/src/main/java/net/aholbrook/paseto/test/data/RfcTestVectors.java

V1 Tests:
https://github.com/atholbro/paseto/blob/master/test/src/main/java/net/aholbrook/paseto/test/PasetoV1Test.java

V2 Tests:
https://github.com/atholbro/paseto/blob/master/test/src/main/java/net/aholbrook/paseto/test/PasetoV2Test.java

Thanks!