### PR TITLE
paseto.io css: avoid x-overflow on the rfc page

### DIFF
--- a/public/paseto.css
+++ b/public/paseto.css
@@ -8,5 +8,5 @@
     font-size: 100%;
     margin: 0 auto 1.5em auto;
     padding: 1ex;
-    width: 83ex;
+    width: 84ex;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1627760/44316727-da056580-a3f2-11e8-81e6-99c888e3135d.png)

After:
![image](https://user-images.githubusercontent.com/1627760/44316737-e984ae80-a3f2-11e8-887e-58a7e029b761.png)

