### PR TITLE
Add new Rust implementation

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -98,6 +98,31 @@
     "audits": []
   },
   {
+    "name": "brycx/pasetors",
+    "url": "https://github.com/brycx/pasetors",
+    "authors": [
+      {
+        "name": "Johannes",
+        "email": "brycx@protonmail.com",
+        "homepage": "https://github.com/brycx/"
+      }
+    ],
+    "comment": null,
+    "language": "Rust",
+    "features": {
+      "v1.local": false,
+      "v1.public": false,
+      "v2.local": true,
+      "v2.public": true
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
+    },
+    "audits": []
+  },
+  {
     "name": "dustinsoftware/paseto.net",
     "url": "https://github.com/dustinsoftware/paseto.net",
     "authors": [


### PR DESCRIPTION
This adds a new Rust [implementation](https://github.com/brycx/pasetors), with support for `v2` only. 