### PR TITLE
remove v2.local for panva/paseto

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -208,7 +208,7 @@
     "features": {
       "v1.local": true,
       "v1.public": true,
-      "v2.local": true,
+      "v2.local": false,
       "v2.public": true
     },
     "extra": {


### PR DESCRIPTION
I've removed v2.local because libsodium is just too massive of a dependency and openssl doesn't support `XChaCha20-Poly1305`.