### PR TITLE
go-paseto now supports v3.public

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -675,7 +675,7 @@
       "v2.local": true,
       "v2.public": true,
       "v3.local": true,
-      "v3.public": false,
+      "v3.public": true,
       "v4.local": true,
       "v4.public": true
     },


### PR DESCRIPTION
As of: [go-paseto@v1.1.0](https://github.com/aidantwoods/go-paseto/releases/tag/v1.1.0)

Additional details: https://github.com/aidantwoods/go-paseto/pull/1