### PR TITLE
Update support for v3.public in swift-paseto

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -103,7 +103,7 @@
       "v2.local": true,
       "v2.public": true,
       "v3.local": true,
-      "v3.public": false,
+      "v3.public": true,
       "v4.local": true,
       "v4.public": true
     },


### PR DESCRIPTION
Supported as of [swift-paseto@1.1.0](https://github.com/aidantwoods/swift-paseto/releases/tag/1.1.0).

More details: https://github.com/aidantwoods/swift-paseto/pull/14.