### PR TITLE
Add paseto-haskell to implementations.json

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -744,5 +744,34 @@
       "working": true
     },
     "audits": []
+  },
+  {
+    "name": "paseto-haskell",
+    "url": "https://github.com/intricate/paseto-haskell",
+    "authors": [
+      {
+        "name": "intricate",
+        "homepage": "https://github.com/intricate"
+      }
+    ],
+    "comment": null,
+    "language": "Haskell",
+    "features": {
+      "v1.local": false,
+      "v1.public": false,
+      "v2.local": false,
+      "v2.public": false,
+      "v3.local": true,
+      "v3.public": true,
+      "v4.local": true,
+      "v4.public": true,
+      "paserk": false
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
+    },
+    "audits": []
   }
 ]


### PR DESCRIPTION
Add [`paseto-haskell`](https://github.com/intricate/paseto-haskell) (only supports versions 3 and 4) to the list of implementations.

There are also [tests for the official `v3` and `v4` vectors](https://github.com/intricate/paseto-haskell/blob/0d2f33afa17a57f80848c63adc9788ddc73d1ef0/paseto/test/Test/Crypto/Paseto/TestVectorTest.hs).