### PR TITLE
feat: update rusty-paseto PASERK support to true

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -194,7 +194,7 @@
       "v3.public": true,
       "v4.local": true,
       "v4.public": true,
-      "paserk": false
+      "paserk": true
     },
     "extra": {
       "test-vectors-exist": true,


### PR DESCRIPTION
## Summary
- Updates rusty-paseto's PASERK support from `false` to `true` in implementations.json
- rusty_paseto now supports PASERK as of v0.9.0

## Test plan
- [x] Verified JSON structure remains valid
- [x] Change is limited to the PASERK feature flag for rusty-paseto