### PR TITLE
feat: Adds paseto-wasm implementation to the registry

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -802,5 +802,35 @@
       "working": true
     },
     "audits": []
+  },
+  {
+    "name": "paseto-wasm",
+    "url": "https://github.com/achmadk/paseto-wasm",
+    "authors": [
+      {
+        "name": "Achmad Kurnianto",
+        "homepage": "https://achmadk.com",
+        "email": "me@achmadk.com"
+      }
+    ],
+    "comment": "A PASETO implementation in Rust with WebAssembly (WASM) bindings",
+    "language": "TypeScript",
+    "features": {
+      "v1.local": false,
+      "v1.public": false,
+      "v2.local": false,
+      "v2.public": false,
+      "v3.local": true,
+      "v3.public": true,
+      "v4.local": true,
+      "v4.public": true,
+      "paserk": true
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
+    },
+    "audits": []
   }
 ]


### PR DESCRIPTION
Introduces a new PASETO implementation written in Rust with WebAssembly bindings, supporting v3, v4, and PASERK features. The entry includes verification that it passes test vectors and is marked as working.