### PR TITLE
Add paseto-kit (TypeScript: v3/v4 + PASERK) to implementations

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -832,5 +832,34 @@
       "working": true
     },
     "audits": []
+  },
+  {
+    "name": "paseto-kit",
+    "url": "https://github.com/Elalitareq/paseto-kit",
+    "authors": [
+      {
+        "name": "Tareq El-Ali",
+        "homepage": "https://github.com/Elalitareq"
+      }
+    ],
+    "comment": "Runtime-agnostic (Node, Deno, Bun, browsers, edge). Full PASERK. Maintained successor to panva/paseto.",
+    "language": "TypeScript",
+    "features": {
+      "v1.local": false,
+      "v1.public": false,
+      "v2.local": false,
+      "v2.public": false,
+      "v3.local": true,
+      "v3.public": true,
+      "v4.local": true,
+      "v4.public": true,
+      "paserk": true
+    },
+    "extra": {
+      "test-vectors-exist": true,
+      "test-vectors-pass": true,
+      "working": true
+    },
+    "audits": []
   }
 ]


### PR DESCRIPTION
Adds **paseto-kit** to the implementations list.

- **Repo:** https://github.com/Elalitareq/paseto-kit · **npm:** `paseto-kit`
- **Language:** TypeScript, runtime-agnostic (Node, Deno, Bun, browsers, edge) — built on the audited `@noble/*` primitives, no Node built-ins.
- **Protocols:** v3 (local + public) and v4 (local + public).
- **PASERK:** full support for both versions (serialize, `lid`/`pid`/`sid`, `local-wrap`/`secret-wrap`, `local-pw`/`secret-pw`, `seal`).
- **Test vectors:** passes the official PASETO and PASERK vectors, including the `expect-fail` cases.

Context: it's positioned as a maintained successor to `panva/paseto` (archived March 2025). It has not yet had an independent third-party security audit, so `audits` is left empty. Happy to adjust the entry's fields if anything should be represented differently.