### PR TITLE
update panva/paseto

### DIFF
--- a/data/implementations.json
+++ b/data/implementations.json
@@ -297,8 +297,8 @@
         "homepage": "https://github.com/panva"
       }
     ],
-    "comment": null,
-    "language": "Node.js",
+    "comment": "Zero-dependency, tree-shakeable PASETO and PASERK for Web-interoperable runtimes, with composable operations, native CryptoKey support, and pluggable cryptographic backends across versions.",
+    "language": "JavaScript",
     "features": {
       "v1.local": true,
       "v1.public": true,
@@ -842,7 +842,7 @@
         "homepage": "https://github.com/Elalitareq"
       }
     ],
-    "comment": "Runtime-agnostic (Node, Deno, Bun, browsers, edge). Full PASERK. Maintained successor to panva/paseto.",
+    "comment": "Runtime-agnostic (Node, Deno, Bun, browsers, edge). Full PASERK.",
     "language": "TypeScript",
     "features": {
       "v1.local": false,


### PR DESCRIPTION
Back from the slumber. Now runtime agnostic, fully typed, composable, tree-shakeable, full PASERK, and fully extensible with custom signers. I didn't check v2.local and v4.local as supported merely because they aren't bundled but if https://github.com/panva/paseto/tree/main/examples#noble-local-examples is enough i'm more than happy to add two more ✅.

For future versions i'd appreciate sticking to readily available browser primitives so that this gap isn't needed.

Closes: #53 